### PR TITLE
Add Drawer Kick

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -292,11 +292,14 @@
                         <span class="visually-hidden">Settings</span>
                     </button>
                     <ul class="dropdown-menu">
-                        <li><a id="printtest_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
+                        <li><a id="printtest_${idx}"   data-printer-idx="${idx}" class="dropdown-item" href="#">
                             Print test page
                         </a></li>
                         <li><a id="printconfig_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
                             Print config
+                        </a></li>
+                        <li><a id="drawerkick_${idx}"  data-printer-idx="${idx}" class="dropdown-item" href="#">
+                            Kick drawer out
                         </a></li>
                     </ul>
                 </div>
@@ -346,6 +349,16 @@
                         const printer = this.printers[printerIdx];
                         const doc = {
                           commands: [new WebReceipt.TestPrint('printerStatus')]
+                        };
+                        await printer.sendDocument(doc);
+                    });
+                document.getElementById(`drawerkick_${idx}`)
+                    .addEventListener('click', async (e) => {
+                        e.preventDefault();
+                        const printerIdx = e.currentTarget.dataset.printerIdx as number;
+                        const printer = this.printers[printerIdx];
+                        const doc = {
+                          commands: [new WebReceipt.PulseCommand()]
                         };
                         await printer.sendDocument(doc);
                     });

--- a/src/Documents/Commands.ts
+++ b/src/Documents/Commands.ts
@@ -136,12 +136,12 @@ export class PulseCommand implements IPrinterCommand {
   public readonly offMS: number;
   public readonly pulsePin: PulsePin;
   constructor(
+    /** Which device pin to pulse on */
+    pulsePin: PulsePin = "Pin2",
     /** Milliseconds pulse is on for, up to 500ms. */
     onMS: number = 100,
     /** Milliseconds pulse is off for. Must be greater than on time. Up to 500ms */
     offMS: number = 500,
-    /** Which device pin to pulse on */
-    pulsePin: PulsePin = "Pin2"
   ) {
     this.onMS = Math.floor(Math.min(500, onMS ?? 100));
     this.offMS = Math.floor(Math.min(500, offMS ?? 500));

--- a/src/Documents/Commands.ts
+++ b/src/Documents/Commands.ts
@@ -122,7 +122,7 @@ export class Cut implements IPrinterCommand {
   ) {}
 }
 
-export type PulsePin = "Pin2" | "Pin5"
+export type PulsePin = "Drawer1" | "Drawer2"
 
 export class PulseCommand implements IPrinterCommand {
   name = "Pulse the drawer kick output.";
@@ -137,7 +137,7 @@ export class PulseCommand implements IPrinterCommand {
   public readonly pulsePin: PulsePin;
   constructor(
     /** Which device pin to pulse on */
-    pulsePin: PulsePin = "Pin2",
+    pulsePin: PulsePin = "Drawer1",
     /** Milliseconds pulse is on for, up to 500ms. */
     onMS: number = 100,
     /** Milliseconds pulse is off for. Must be greater than on time. Up to 500ms */

--- a/src/Printers/Languages/EscPos/EscPos.ts
+++ b/src/Printers/Languages/EscPos/EscPos.ts
@@ -237,8 +237,8 @@ export class EscPos extends RawCommandSet {
   private pulseHandler(cmd: Cmds.PulseCommand) {
     let pin: number
     switch (cmd.pulsePin) {
-      case "Pin2": pin = 0x00;
-      case "Pin5": pin = 0x01;
+      case "Pin2": pin = 0x00; break;
+      case "Pin5": pin = 0x01; break;
     }
     const onMS = Math.floor(cmd.onMS / 2);
     const offMS = Math.floor(cmd.offMS / 2);

--- a/src/Printers/Languages/EscPos/EscPos.ts
+++ b/src/Printers/Languages/EscPos/EscPos.ts
@@ -235,14 +235,14 @@ export class EscPos extends RawCommandSet {
   }
 
   private pulseHandler(cmd: Cmds.PulseCommand) {
-    let pin: number
+    let drawer: number
     switch (cmd.pulsePin) {
-      case "Pin2": pin = 0x00; break;
-      case "Pin5": pin = 0x01; break;
+      case "Drawer1": drawer = 0x00; break;
+      case "Drawer2": drawer = 0x01; break;
     }
     const onMS = Math.floor(cmd.onMS / 2);
     const offMS = Math.floor(cmd.offMS / 2);
-    return new Uint8Array([Ascii.ESC, this.enc('p'), pin, onMS, offMS]);
+    return new Uint8Array([Ascii.ESC, this.enc('p'), drawer, onMS, offMS]);
   }
 
   private setTextFormatting(f: Cmds.TextFormat, docState: EscPosDocState) {

--- a/src/ReceiptLine/Parser.ts
+++ b/src/ReceiptLine/Parser.ts
@@ -341,11 +341,11 @@ function columnsToLine(
     if (propMembers.has('drawer')) {
       switch (propMembers.get('drawer')) {
         case 'kick':
-        case 'pin2':
-          lineElement.drawerKick = 'Pin2';
+        case '1':
+          lineElement.drawerKick = 'Drawer1';
           break;
-        case 'pin5':
-          lineElement.drawerKick = 'Pin5';
+        case '2':
+          lineElement.drawerKick = 'Drawer2';
           break;
       }
     }

--- a/src/ReceiptLine/Parser.ts
+++ b/src/ReceiptLine/Parser.ts
@@ -45,6 +45,7 @@ interface lineElement {
   vr?: LineRuleNext;
   hr?: boolean;
   cut?: boolean;
+  drawerKick?: Cmds.PulsePin;
 }
 
 interface formattedText {
@@ -334,6 +335,19 @@ function columnsToLine(
     // parse code property
     if (propMembers.has('code')) {
       lineElement.code = Object.assign({ data: propMembers.get('code') }, state.barcodeOptions);
+    }
+
+    // parse drawer kick property
+    if (propMembers.has('drawer')) {
+      switch (propMembers.get('drawer')) {
+        case 'kick':
+        case 'pin2':
+          lineElement.drawerKick = 'Pin2';
+          break;
+        case 'pin5':
+          lineElement.drawerKick = 'Pin5';
+          break;
+      }
     }
 
     // parse image property
@@ -802,14 +816,16 @@ function createLine(
     }
   }
 
+  if (firstColumn.drawerKick !== undefined) {
+    lineCmds.push(
+      new Cmds.PulseCommand(firstColumn.drawerKick)
+    )
+  }
+
   // process image
   if (firstColumn.image !== undefined) {
     // append commands to print image
     lineCmds.push(
-      // printer.command.normal() +
-      // printer.command.area(left, width, right) +
-      // printer.command.align(column.align) +
-      // printer.command.image(column.image));
       ...resetFormattingCmds(left, width, right, firstColumn.align),
       new Cmds.ImageCommand(firstColumn.image),
     );
@@ -819,10 +835,6 @@ function createLine(
   if (firstColumn.code !== undefined) {
     // append commands to print barcode
     lineCmds.push(
-      // printer.command.normal() +
-      // printer.command.area(left, width, right) +
-      // printer.command.align(column.align) +
-      // printer.command.barcode(column.code, printer.encoding)
       ...resetFormattingCmds(left, width, right, firstColumn.align),
       new Cmds.Barcode(firstColumn.code),
     );
@@ -832,10 +844,6 @@ function createLine(
   if (firstColumn.command !== undefined) {
     // append commands to insert commands
     lineCmds.push(
-      // printer.command.normal() +
-      // printer.command.area(left, width, right) +
-      // printer.command.align(column.align) +
-      // printer.command.command(column.command)
       ...resetFormattingCmds(left, width, right, firstColumn.align),
       new Cmds.RawCommand(firstColumn.command)
     );


### PR DESCRIPTION
The official spec for Receiptline omits any functions for the drawer kick function on printers. Instead they suggest the use of the `{command:}` option. I'm not a fan as this will always be language-specific, and for this particular library I have the leeway to extend the syntax of options at least a little bit.

This adds a `{drawer:kick}` option to the parser to allow documents to indicate the cash drawer kick should be, well, kicked. The alias value `kick` maps to `1`, for output 1. Some printers support two outputs, so `2` is also a supported input value.

* `{drawer:kick}`
* `{drawer:1}`
* `{drawer:2}`

are valid options for syntax and will result in the drawer kick command being added to the document.