### PR TITLE
Add device connected state

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-receiptline-printer",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-rc1",
   "description": "A small Library for printing ReceiptLine documents to various receipt printers from a browser.",
   "type": "module",
   "repository": {

--- a/src/Printers/Communication/DeviceCommunication.ts
+++ b/src/Printers/Communication/DeviceCommunication.ts
@@ -48,6 +48,9 @@ export interface IDeviceChannel<TOutput, TInput> {
   /** A promise indicating this communication channel is ready for use. */
   get ready(): Promise<boolean>;
 
+  /** Whether the device is connected. */
+  get connected(): boolean;
+
   /** Close the channel, disallowing future communication. */
   dispose(): Promise<void>;
 

--- a/src/Printers/ReceiptPrinter.ts
+++ b/src/Printers/ReceiptPrinter.ts
@@ -64,6 +64,10 @@ export class ReceiptPrinter extends EventTarget implements IDevice {
   get ready() {
     return this._ready;
   }
+  get connected() {
+    return !this._disposed
+      && this._channel.connected
+  }
 
   /** Construct a new printer from a given USB device. */
   static fromUSBDevice(device: USBDevice, options: IDeviceCommunicationOptions): ReceiptPrinter {
@@ -115,7 +119,7 @@ export class ReceiptPrinter extends EventTarget implements IDevice {
       return false;
     }
 
-    this._printerOptions.update(deviceInfoToOptionsUpdate(this._channel.getDeviceInfo()))
+    this._printerOptions.update(deviceInfoToOptionsUpdate(this._channel.getDeviceInfo()));
 
     // TODO: language detection
     this._commandSet = new EscPos();
@@ -132,6 +136,7 @@ export class ReceiptPrinter extends EventTarget implements IDevice {
   /** Close the connection to this printer, preventing future communication. */
   public async dispose() {
     this._disposed = true;
+    this._ready = Promise.resolve(false);
     this._streamListener?.dispose();
     await this._channel.dispose();
   }


### PR DESCRIPTION
I suspect systems would like to know if the printer they're going to talk to is still there or not.

This adds a `connected` getter to both the ReceiptPrinter object and the DeviceChannel object, which is what gets rolled into the printer status.