### PR TITLE
Ignore unmanaged device conneciton events

### DIFF
--- a/demo/demo-sw.js
+++ b/demo/demo-sw.js
@@ -12,17 +12,15 @@ self.addEventListener('activate', () => self.clients.claim());
 
 // Intercept fetch requests for modules and compile the intercepted typescript.
 self.addEventListener('fetch', (event) => {
+    if (!event.request.url.startsWith('https://')) {
+        return;
+    }
+
     // Start off easy: if it's a request for a TS file, transpile it.
     if (event.request.url.endsWith('.ts')) {
         log('Fetching', event.request.url, 'as just typescript');
         event.respondWith(transpileTypeScript(event.request.url));
         return;
-    }
-
-    // Some sanity checks
-    if (!event.request.url.startsWith('http')) {
-      // chrome-extension:// should be ignored, for example.
-      return;
     }
 
     // Next up is 'no extension'. In classical TS imports you omit any extension
@@ -108,7 +106,7 @@ const transpileTypeScript = async (requestUrl) => {
     };
 
     const transpiledResponse = new Response(transpiledCode, responseOptions);
-    if (!requestUrl.startsWith('https://localhost')) {
+    if (!requestUrl.startsWith('https://localhost') && requestUrl.startsWith('https://')) {
         typescriptCache.put(requestUrl, transpiledResponse.clone());
     }
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -75,6 +75,7 @@
 
     <!-- Here's some actual demo code. Note that it is typescript, not javascript. -->
     <script type="text/typescript" id="cool_demo_code_to_show_off_the_lib">
+      // First import the lib!
       import * as WebReceipt from 'web-receiptline-printer';
 
       // For this demo we're going to make use of the USB printer manager
@@ -99,16 +100,16 @@
 
       // We'll wire up some basic event listeners to the printer manager.
       // First, a button to prompt a user to add a printer.
-      const addPrinterBtn = document.getElementById('addprinter');
+      const addPrinterBtn = document.getElementById('addprinter')!;
       addPrinterBtn.addEventListener('click', async () => printerMgr.promptForNewDevice());
 
       // Next a button to manually refresh all printers, just in case.
-      const refreshPrinterBtn = document.getElementById('refreshPrinters');
+      const refreshPrinterBtn = document.getElementById('refreshPrinters')!;
       refreshPrinterBtn.addEventListener('click', async () => printerMgr.forceReconnect());
 
       // Next we wire up some events on the device manager itself.
       printerMgr.addEventListener('connectedDevice', ({ detail }) => {
-        const printer = detail;
+        const printer = detail.device;
         const config = printer.printerOptions;
         console.log(`Printer is a ${config.model} by ${config.manufacturer}, serial ${config.serialNumber}`);
         console.log(`Printer has ${config.charactersPerLine} characters per line`);
@@ -116,7 +117,7 @@
 
       // There's also an event that will tell you when a printer disconnects.
       printerMgr.addEventListener('disconnectedDevice', ({ detail }) => {
-        const printer = detail;
+        const printer = detail.device;
         // TODO: Hide appropriate interface.
         console.log(`Lost printer ${printer.printerModel} (${printer.printerOptions.serialNumber}).`);
       });
@@ -131,365 +132,199 @@
       // And that's all there is to setup! The page can now talk to printers.
       // The rest of this demo is an example of a basic receipt printer app.
 
-        // The app's logic is wrapped in a class just for ease of reading.
-        class BasicDocumentPrinterApp {
-            constructor(
-                manager: WebReceipt.UsbDeviceManager<WebReceipt.ReceiptPrinter>,
-                btnContainer: HTMLElement,
-                labelForm: HTMLElement,
-                labelFormInstructions: HTMLElement,
-                configModal: HTMLElement
-            ) {
-                this.manager = manager;
-                this.btnContainer = btnContainer;
-                this.labelForm = labelForm;
-                this.labelFormInstructions = labelFormInstructions;
-                this.configModal = configModal;
-
-                // Based on the containers, map the various listeners.
-                //this.configModalHandle = new bootstrap.Modal(this.configModal);
-                //this.configModal
-                //    .querySelector('form')
-                //    .addEventListener('submit', this.updatePrinterConfig.bind(this));
-                //this.labelForm.addEventListener('blur', this.renderTextForm.bind(this));
-                //this.labelForm.addEventListener('keyup', this.renderTextForm.bind(this));
-
-                // Add a second set of event listeners for printer connect and disconnect to redraw
-                // the printer list when it changes.
-                this.manager.addEventListener('connectedDevice', ({ detail }) => {
-                    this.activePrinterIndex = -1;
-                    this.redrawPrinterButtons();
-                });
-                this.manager.addEventListener('disconnectedDevice', ({ detail }) => {
-                    this.activePrinterIndex = -1;
-                    this.redrawPrinterButtons();
-                });
-
-                // Here's a nice font with a great set of emoji that work well for monochrome printing.
-                // The text font is fairly basic though, so we would like to use only the emoji out
-                // of this font and use a basic sans-serif font for regular text.
-                // https://fonts.google.com/noto/specimen/Noto+Emoji
-                const emojiFontName = 'noto-emoji';
-
-                // We can accomplish this with the unicodeRange property of our FontFace. We just
-                // need to list EVERY SINGLE EMOJI UNICODE RANGE to make it work. Fortunately someone
-                // has done this already: https://github.com/fraction/emoji-unicode-range
-                const emojiUnicodeRange = 'U+00A9,U+00AE,U+203C,U+2049,U+2122,U+2139,U+2194-2199,U+21A9-21AA,U+231A-231B,U+2328,U+23CF,U+23E9-23F3,U+23F8-23FA,U+24C2,U+25AA-25AB,U+25B6,U+25C0,U+25FB-25FE,U+2600-2604,U+260E,U+2611,U+2614-2615,U+2618,U+261D,U+2620,U+2622-2623,U+2626,U+262A,U+262E-262F,U+2638-263A,U+2640,U+2642,U+2648-2653,U+265F-2660,U+2663,U+2665-2666,U+2668,U+267B,U+267E-267F,U+2692-2697,U+2699,U+269B-269C,U+26A0-26A1,U+26AA-26AB,U+26B0-26B1,U+26BD-26BE,U+26C4-26C5,U+26C8,U+26CE,U+26CF,U+26D1,U+26D3-26D4,U+26E9-26EA,U+26F0-26F5,U+26F7-26FA,U+26FD,U+2702,U+2705,U+2708-2709,U+270A-270B,U+270C-270D,U+270F,U+2712,U+2714,U+2716,U+271D,U+2721,U+2728,U+2733-2734,U+2744,U+2747,U+274C,U+274E,U+2753-2755,U+2757,U+2763-2764,U+2795-2797,U+27A1,U+27B0,U+27BF,U+2934-2935,U+2B05-2B07,U+2B1B-2B1C,U+2B50,U+2B55,U+3030,U+303D,U+3297,U+3299,U+1F004,U+1F0CF,U+1F170-1F171,U+1F17E,U+1F17F,U+1F18E,U+1F191-1F19A,U+1F1E6-1F1FF,U+1F201-1F202,U+1F21A,U+1F22F,U+1F232-1F23A,U+1F250-1F251,U+1F300-1F320,U+1F321,U+1F324-1F32C,U+1F32D-1F32F,U+1F330-1F335,U+1F336,U+1F337-1F37C,U+1F37D,U+1F37E-1F37F,U+1F380-1F393,U+1F396-1F397,U+1F399-1F39B,U+1F39E-1F39F,U+1F3A0-1F3C4,U+1F3C5,U+1F3C6-1F3CA,U+1F3CB-1F3CE,U+1F3CF-1F3D3,U+1F3D4-1F3DF,U+1F3E0-1F3F0,U+1F3F3-1F3F5,U+1F3F7,U+1F3F8-1F3FF,U+1F400-1F43E,U+1F43F,U+1F440,U+1F441,U+1F442-1F4F7,U+1F4F8,U+1F4F9-1F4FC,U+1F4FD,U+1F4FF,U+1F500-1F53D,U+1F549-1F54A,U+1F54B-1F54E,U+1F550-1F567,U+1F56F-1F570,U+1F573-1F579,U+1F57A,U+1F587,U+1F58A-1F58D,U+1F590,U+1F595-1F596,U+1F5A4,U+1F5A5,U+1F5A8,U+1F5B1-1F5B2,U+1F5BC,U+1F5C2-1F5C4,U+1F5D1-1F5D3,U+1F5DC-1F5DE,U+1F5E1,U+1F5E3,U+1F5E8,U+1F5EF,U+1F5F3,U+1F5FA,U+1F5FB-1F5FF,U+1F600,U+1F601-1F610,U+1F611,U+1F612-1F614,U+1F615,U+1F616,U+1F617,U+1F618,U+1F619,U+1F61A,U+1F61B,U+1F61C-1F61E,U+1F61F,U+1F620-1F625,U+1F626-1F627,U+1F628-1F62B,U+1F62C,U+1F62D,U+1F62E-1F62F,U+1F630-1F633,U+1F634,U+1F635-1F640,U+1F641-1F642,U+1F643-1F644,U+1F645-1F64F,U+1F680-1F6C5,U+1F6CB-1F6CF,U+1F6D0,U+1F6D1-1F6D2,U+1F6D5,U+1F6E0-1F6E5,U+1F6E9,U+1F6EB-1F6EC,U+1F6F0,U+1F6F3,U+1F6F4-1F6F6,U+1F6F7-1F6F8,U+1F6F9,U+1F6FA,U+1F7E0-1F7EB,U+1F90D-1F90F,U+1F910-1F918,U+1F919-1F91E,U+1F91F,U+1F920-1F927,U+1F928-1F92F,U+1F930,U+1F931-1F932,U+1F933-1F93A,U+1F93C-1F93E,U+1F93F,U+1F940-1F945,U+1F947-1F94B,U+1F94C,U+1F94D-1F94F,U+1F950-1F95E,U+1F95F-1F96B,U+1F96C-1F970,U+1F971,U+1F973-1F976,U+1F97A,U+1F97B,U+1F97C-1F97F,U+1F980-1F984,U+1F985-1F991,U+1F992-1F997,U+1F998-1F9A2,U+1F9A5-1F9AA,U+1F9AE-1F9AF,U+1F9B0-1F9B9,U+1F9BA-1F9BF,U+1F9C0,U+1F9C1-1F9C2,U+1F9C3-1F9CA,U+1F9CD-1F9CF,U+1F9D0-1F9E6,U+1F9E7-1F9FF,U+1FA70-1FA73,U+1FA78-1FA7A,U+1FA80-1FA82,U+1FA90-1FA95,U+231A-231B,U+23E9-23EC,U+23F0,U+23F3,U+25FD-25FE,U+2614-2615,U+2648-2653,U+267F,U+2693,U+26A1,U+26AA-26AB,U+26BD-26BE,U+26C4-26C5,U+26CE,U+26D4,U+26EA,U+26F2-26F3,U+26F5,U+26FA,U+26FD,U+2705,U+270A-270B,U+2728,U+274C,U+274E,U+2753-2755,U+2757,U+2795-2797,U+27B0,U+27BF,U+2B1B-2B1C,U+2B50,U+2B55,U+1F004,U+1F0CF,U+1F18E,U+1F191-1F19A,U+1F1E6-1F1FF,U+1F201,U+1F21A,U+1F22F,U+1F232-1F236,U+1F238-1F23A,U+1F250-1F251,U+1F300-1F320,U+1F32D-1F32F,U+1F330-1F335,U+1F337-1F37C,U+1F37E-1F37F,U+1F380-1F393,U+1F3A0-1F3C4,U+1F3C5,U+1F3C6-1F3CA,U+1F3CF-1F3D3,U+1F3E0-1F3F0,U+1F3F4,U+1F3F8-1F3FF,U+1F400-1F43E,U+1F440,U+1F442-1F4F7,U+1F4F8,U+1F4F9-1F4FC,U+1F4FF,U+1F500-1F53D,U+1F54B-1F54E,U+1F550-1F567,U+1F57A,U+1F595-1F596,U+1F5A4,U+1F5FB-1F5FF,U+1F600,U+1F601-1F610,U+1F611,U+1F612-1F614,U+1F615,U+1F616,U+1F617,U+1F618,U+1F619,U+1F61A,U+1F61B,U+1F61C-1F61E,U+1F61F,U+1F620-1F625,U+1F626-1F627,U+1F628-1F62B,U+1F62C,U+1F62D,U+1F62E-1F62F,U+1F630-1F633,U+1F634,U+1F635-1F640,U+1F641-1F642,U+1F643-1F644,U+1F645-1F64F,U+1F680-1F6C5,U+1F6CC,U+1F6D0,U+1F6D1-1F6D2,U+1F6D5,U+1F6EB-1F6EC,U+1F6F4-1F6F6,U+1F6F7-1F6F8,U+1F6F9,U+1F6FA,U+1F7E0-1F7EB,U+1F90D-1F90F,U+1F910-1F918,U+1F919-1F91E,U+1F91F,U+1F920-1F927,U+1F928-1F92F,U+1F930,U+1F931-1F932,U+1F933-1F93A,U+1F93C-1F93E,U+1F93F,U+1F940-1F945,U+1F947-1F94B,U+1F94C,U+1F94D-1F94F,U+1F950-1F95E,U+1F95F-1F96B,U+1F96C-1F970,U+1F971,U+1F973-1F976,U+1F97A,U+1F97B,U+1F97C-1F97F,U+1F980-1F984,U+1F985-1F991,U+1F992-1F997,U+1F998-1F9A2,U+1F9A5-1F9AA,U+1F9AE-1F9AF,U+1F9B0-1F9B9,U+1F9BA-1F9BF,U+1F9C0,U+1F9C1-1F9C2,U+1F9C3-1F9CA,U+1F9CD-1F9CF,U+1F9D0-1F9E6,U+1F9E7-1F9FF,U+1FA70-1FA73,U+1FA78-1FA7A,U+1FA80-1FA82,U+1FA90-1FA95,U+1F3FB-1F3FF,U+261D,U+26F9,U+270A-270B,U+270C-270D,U+1F385,U+1F3C2-1F3C4,U+1F3C7,U+1F3CA,U+1F3CB-1F3CC,U+1F442-1F443,U+1F446-1F450,U+1F466-1F478,U+1F47C,U+1F481-1F483,U+1F485-1F487,U+1F48F,U+1F491,U+1F4AA,U+1F574-1F575,U+1F57A,U+1F590,U+1F595-1F596,U+1F645-1F647,U+1F64B-1F64F,U+1F6A3,U+1F6B4-1F6B6,U+1F6C0,U+1F6CC,U+1F90F,U+1F918,U+1F919-1F91E,U+1F91F,U+1F926,U+1F930,U+1F931-1F932,U+1F933-1F939,U+1F93C-1F93E,U+1F9B5-1F9B6,U+1F9B8-1F9B9,U+1F9BB,U+1F9CD-1F9CF,U+1F9D1-1F9DD,U+0023,U+002A,U+0030-0039,U+200D,U+20E3,U+FE0F,U+1F1E6-1F1FF,U+1F3FB-1F3FF,U+1F9B0-1F9B3,U+E0020-E007F,U+00A9,U+00AE,U+203C,U+2049,U+2122,U+2139,U+2194-2199,U+21A9-21AA,U+231A-231B,U+2328,U+2388,U+23CF,U+23E9-23F3,U+23F8-23FA,U+24C2,U+25AA-25AB,U+25B6,U+25C0,U+25FB-25FE,U+2600-2605,U+2607-2612,U+2614-2615,U+2616-2617,U+2618,U+2619,U+261A-266F,U+2670-2671,U+2672-267D,U+267E-267F,U+2680-2685,U+2690-2691,U+2692-269C,U+269D,U+269E-269F,U+26A0-26A1,U+26A2-26B1,U+26B2,U+26B3-26BC,U+26BD-26BF,U+26C0-26C3,U+26C4-26CD,U+26CE,U+26CF-26E1,U+26E2,U+26E3,U+26E4-26E7,U+26E8-26FF,U+2700,U+2701-2704,U+2705,U+2708-2709,U+270A-270B,U+270C-2712,U+2714,U+2716,U+271D,U+2721,U+2728,U+2733-2734,U+2744,U+2747,U+274C,U+274E,U+2753-2755,U+2757,U+2763-2767,U+2795-2797,U+27A1,U+27B0,U+27BF,U+2934-2935,U+2B05-2B07,U+2B1B-2B1C,U+2B50,U+2B55,U+3030,U+303D,U+3297,U+3299,U+1F000-1F02B,U+1F02C-1F02F,U+1F030-1F093,U+1F094-1F09F,U+1F0A0-1F0AE,U+1F0AF-1F0B0,U+1F0B1-1F0BE,U+1F0BF,U+1F0C0,U+1F0C1-1F0CF,U+1F0D0,U+1F0D1-1F0DF,U+1F0E0-1F0F5,U+1F0F6-1F0FF,U+1F10D-1F10F,U+1F12F,U+1F16C,U+1F16D-1F16F,U+1F170-1F171,U+1F17E,U+1F17F,U+1F18E,U+1F191-1F19A,U+1F1AD-1F1E5,U+1F201-1F202,U+1F203-1F20F,U+1F21A,U+1F22F,U+1F232-1F23A,U+1F23C-1F23F,U+1F249-1F24F,U+1F250-1F251,U+1F252-1F25F,U+1F260-1F265,U+1F266-1F2FF,U+1F300-1F320,U+1F321-1F32C,U+1F32D-1F32F,U+1F330-1F335,U+1F336,U+1F337-1F37C,U+1F37D,U+1F37E-1F37F,U+1F380-1F393,U+1F394-1F39F,U+1F3A0-1F3C4,U+1F3C5,U+1F3C6-1F3CA,U+1F3CB-1F3CE,U+1F3CF-1F3D3,U+1F3D4-1F3DF,U+1F3E0-1F3F0,U+1F3F1-1F3F7,U+1F3F8-1F3FA,U+1F400-1F43E,U+1F43F,U+1F440,U+1F441,U+1F442-1F4F7,U+1F4F8,U+1F4F9-1F4FC,U+1F4FD-1F4FE,U+1F4FF,U+1F500-1F53D,U+1F546-1F54A,U+1F54B-1F54F,U+1F550-1F567,U+1F568-1F579,U+1F57A,U+1F57B-1F5A3,U+1F5A4,U+1F5A5-1F5FA,U+1F5FB-1F5FF,U+1F600,U+1F601-1F610,U+1F611,U+1F612-1F614,U+1F615,U+1F616,U+1F617,U+1F618,U+1F619,U+1F61A,U+1F61B,U+1F61C-1F61E,U+1F61F,U+1F620-1F625,U+1F626-1F627,U+1F628-1F62B,U+1F62C,U+1F62D,U+1F62E-1F62F,U+1F630-1F633,U+1F634,U+1F635-1F640,U+1F641-1F642,U+1F643-1F644,U+1F645-1F64F,U+1F680-1F6C5,U+1F6C6-1F6CF,U+1F6D0,U+1F6D1-1F6D2,U+1F6D3-1F6D4,U+1F6D5,U+1F6D6-1F6DF,U+1F6E0-1F6EC,U+1F6ED-1F6EF,U+1F6F0-1F6F3,U+1F6F4-1F6F6,U+1F6F7-1F6F8,U+1F6F9,U+1F6FA,U+1F6FB-1F6FF,U+1F774-1F77F,U+1F7D5-1F7D8,U+1F7D9-1F7DF,U+1F7E0-1F7EB,U+1F7EC-1F7FF,U+1F80C-1F80F,U+1F848-1F84F,U+1F85A-1F85F,U+1F888-1F88F,U+1F8AE-1F8FF,U+1F90C,U+1F90D-1F90F,U+1F910-1F918,U+1F919-1F91E,U+1F91F,U+1F920-1F927,U+1F928-1F92F,U+1F930,U+1F931-1F932,U+1F933-1F93A,U+1F93C-1F93E,U+1F93F,U+1F940-1F945,U+1F947-1F94B,U+1F94C,U+1F94D-1F94F,U+1F950-1F95E,U+1F95F-1F96B,U+1F96C-1F970,U+1F971,U+1F972,U+1F973-1F976,U+1F977-1F979,U+1F97A,U+1F97B,U+1F97C-1F97F,U+1F980-1F984,U+1F985-1F991,U+1F992-1F997,U+1F998-1F9A2,U+1F9A3-1F9A4,U+1F9A5-1F9AA,U+1F9AB-1F9AD,U+1F9AE-1F9AF,U+1F9B0-1F9B9,U+1F9BA-1F9BF,U+1F9C0,U+1F9C1-1F9C2,U+1F9C3-1F9CA,U+1F9CB-1F9CC,U+1F9CD-1F9CF,U+1F9D0-1F9E6,U+1F9E7-1F9FF,U+1FA00-1FA53,U+1FA54-1FA5F,U+1FA60-1FA6D,U+1FA6E-1FA6F,U+1FA70-1FA73,U+1FA74-1FA77,U+1FA78-1FA7A,U+1FA7B-1FA7F,U+1FA80-1FA82,U+1FA83-1FA8F,U+1FA90-1FA95,U+1FA96-1FFFD';
-
-                // And then we can use that range with our font when we load it.
-                const emojiOnlyFont = new FontFace(emojiFontName, 'url(fonts/NotoEmoji-Regular.ttf)', {
-                  unicodeRange: emojiUnicodeRange,
-                });
-                emojiOnlyFont.load().then(() => {
-                    document.fonts.add(emojiOnlyFont);
-                });
-                // We then set our fallback font as part of the font family we use in the canvas.
-                // This order matters, latter fonts will use the unicodeRange to override earlier fonts.
-                this.fontName = `Sans-serif, ${emojiFontName}`
-            }
-
-            // Some storage fields and utility properties
-            private btnContainer: HTMLElement;
-            private labelForm: HTMLElement;
-            private labelFormInstructions: HTMLElement;
-            private configModal: HTMLElement;
-            private fontName: string;
-            private manager: WebReceipt.UsbDeviceManager<ReceiptPrinter>;
-            get printers(): readonly WebReceipt.ReceiptPrinter[] {
-                return this.manager.devices;
-            }
-
-            // Track which printer is currently selected for operations
-            private _activePrinter = 0;
-            get activePrinter(): WebReceipt.ReceiptPrinter {
-                return this._activePrinter < 0 || this._activePrinter > this.printers.length
-                    ? null
-                    : this.printers[this._activePrinter];
-            }
-            set activePrinterIndex(printerIdx: number) {
-                this._activePrinter = printerIdx;
-                this.redrawTextCanvas();
-            }
-
-            /** Initialize the app */
-            public async init() {
-                this.redrawPrinterButtons();
-                this.redrawTextCanvas();
-            }
-
-            /** Display the configuration for a printer. */
-            public showConfigModal(printer: WebReceipt.ReceiptPrinter, printerIdx: number) {
-                if (printer == null) {
-                    return;
-                }
-                const config = printer.printerOptions;
-
-                // Translate the available speeds to options to be selected
-                const speedSelect = this.configModal.querySelector('#modalSpeed');
-                speedSelect.innerHTML = '';
-                const speedTable = printer.printerModel.speedTable as ReadonlyMap<PrintSpeed, number>;
-                for (const [key, val] of speedTable) {
-                    // Skip utility values, so long as there's more than the defaults.
-                    // Mobile printers *only* support auto, for example.
-                    if ((speedTable.length > 3)
-                        && (key == PrintSpeed.auto
-                            || key == PrintSpeed.ipsPrinterMax
-                            || key == PrintSpeed.ipsPrinterMin)) {
-                        continue;
-                    }
-                    const opt = document.createElement('option');
-                    opt.value = key;
-                    opt.innerHTML = PrintSpeed[key].substring(3).replaceAll('_', '.') + ' ips';
-                    speedSelect.appendChild(opt);
-                }
-                speedSelect.value = config.speed.printSpeed;
-
-                this.configModal.querySelector('#modalPrinterIndex').value = config.serialNumber;
-                this.configModal.querySelector('#modalPrinterIndexText').textContent = printerIdx;
-                this.configModal.querySelector('#modalLabelWidth').value = config.labelWidthInches;
-                this.configModal.querySelector('#modalLabelHeight').value = config.labelHeightInches;
-                this.configModal.querySelector('#modalDarkness').value = config.darknessPercent;
-                this.configModalHandle.show();
-            }
-
-            /** Erase and re-draw the list of printer buttons in the UI. */
-            private redrawPrinterButtons() {
-                this.btnContainer.innerHTML = '';
-                this.printers.forEach((printer, idx) => this.drawPrinterButton(printer, idx));
-            }
-
-            /** Highlight only the currently selected printer. */
-            private redrawPrinterButtonHighlights() {
-                this.printers.forEach((printer, idx) => {
-                    const element = document.getElementById(`printer_${idx}`);
-                    const highlight = this._activePrinter == idx ? "var(--bs-blue)" : "transparent";
-                    element.style.background = `linear-gradient(to right, ${highlight}, ${highlight}, grey, grey)`;
-                });
-            }
-
-            /** Add a printer's button UI to the list of printers. */
-            private drawPrinterButton(printer: WebReceipt.ReceiptPrinter, idx: number) {
-                const highlight = this._activePrinter == idx ? "var(--bs-blue)" : "transparent";
-
-                // Generate a new label printer button for the given printer.
-                const element = document.createElement("div");
-                element.innerHTML = `
-    <li id="printer_${idx}" data-printer-idx="${idx}"
-        class="list-group-item d-flex flex-row justify-content-between sligh-items-start"
-        style="background: linear-gradient(to right, ${highlight}, ${highlight}, grey, grey);">
-        <div class="col-sm-8">
-            <div class="col-sm-12">
-                <span data-serial="${printer.printerOptions.serialNumber}">${printer.printerOptions.serialNumber}</span>
-            </div>
-            <div class="col-sm-12">
-                <span>${printer.printerOptions.charactersPerLine} cpl</span>
-            </div>
-        </div>
-        <div class="d-flex flex-row justify-content-end">
-            <div class="btn-group" role="group" aria-label="Printer button group">
-                <button id="printto_${idx}" class="btn btn-success btn-lg" data-label-width="${printer.labelWidth}" data-label-height="${printer.labelHeight}" data-printer-idx="${idx}">🖨</button>
-                    <button class="btn btn-success dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
-                        <span class="visually-hidden">Settings</span>
-                    </button>
-                    <ul class="dropdown-menu">
-                        <li><a id="printtest_${idx}"   data-printer-idx="${idx}" class="dropdown-item" href="#">
-                            Print test page
-                        </a></li>
-                        <li><a id="printconfig_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
-                            Print config
-                        </a></li>
-                        <li><a id="drawerkick_${idx}"  data-printer-idx="${idx}" class="dropdown-item" href="#">
-                            Kick drawer out
-                        </a></li>
-                    </ul>
-                </div>
-            </div>
-        </div>
-    </li>`;
-                // And slap it into the button container.
-                this.btnContainer.appendChild(element);
-
-                // Then wire up the button events so they work.
-                document.getElementById(`printto_${idx}`)
-                    .addEventListener('click', async (e) => {
-                        e.preventDefault();
-                        const printerIdx = e.currentTarget.dataset.printerIdx as number;
-                        const printer = this.printers[printerIdx];
-                        const textarea = this.labelForm.querySelector('#labelFormText') as HTMLTextAreaElement;
-                        const rawReceiptline = textarea.value;
-                        const doc = WebReceipt.parseReceiptLineToDocument(rawReceiptline, printer.printerOptions);
-                        await printer.sendDocument(doc);
-                    });
-                document.getElementById(`printer_${idx}`)
-                    .addEventListener('click', async (e) => {
-                        e.preventDefault();
-                        const printerIdx = e.currentTarget.dataset.printerIdx as number;
-                        if (this._activePrinter == printerIdx) {
-                            // Don't refresh anything if we already have this printer selected..
-                            return;
-                        }
-                        this.activePrinterIndex = printerIdx;
-                        this.redrawPrinterButtonHighlights();
-                        this.redrawTextCanvas();
-                    });
-                document.getElementById(`printtest_${idx}`)
-                    .addEventListener('click', async (e) => {
-                        e.preventDefault();
-                        const printerIdx = e.currentTarget.dataset.printerIdx as number;
-                        const printer = this.printers[printerIdx];
-                        const doc = {
-                          commands: [new WebReceipt.TestPrint('rolling')]
-                        };
-                        await printer.sendDocument(doc);
-                    });
-                document.getElementById(`printconfig_${idx}`)
-                    .addEventListener('click', async (e) => {
-                        e.preventDefault();
-                        const printerIdx = e.currentTarget.dataset.printerIdx as number;
-                        const printer = this.printers[printerIdx];
-                        const doc = {
-                          commands: [new WebReceipt.TestPrint('printerStatus')]
-                        };
-                        await printer.sendDocument(doc);
-                    });
-                document.getElementById(`drawerkick_${idx}`)
-                    .addEventListener('click', async (e) => {
-                        e.preventDefault();
-                        const printerIdx = e.currentTarget.dataset.printerIdx as number;
-                        const printer = this.printers[printerIdx];
-                        const doc = {
-                          commands: [new WebReceipt.PulseCommand()]
-                        };
-                        await printer.sendDocument(doc);
-                    });
-            }
-
-            /** Redraw the text canvas size according to the printer. */
-            private redrawTextCanvas() {
-              const printer = this.activePrinter;
-              if (printer == null) {
-                  this.labelForm.classList.add('d-none');
-                  this.labelFormInstructions.classList.remove('d-none');
-                  return;
-              } else {
-                  this.labelForm.classList.remove('d-none');
-                  this.labelFormInstructions.classList.add('d-none');
-              }
-
-              const textarea = this.labelForm.querySelector('#labelFormText') as HTMLTextAreaElement;
-              textarea.value = "Enter your ReceiptLine text here!";
-            }
-
-            /** Render the text form to the canvas */
-            // private renderTextForm(e: KeyboardEvent) {
-            //     const printer = this.activePrinter;
-            //     if (printer == null) {
-            //         return;
-            //     }
-
-            //     const textarea = this.labelForm.querySelector('#labelFormText') as HTMLTextAreaElement;
-            //     const canvas = this.labelForm.querySelector("#labelCanvas") as HTMLCanvasElement;
-            //     const pageContext = canvas.getContext('2d');
-            //     pageContext.clearRect(0, 0, canvas.width, canvas.height);
-
-            //     // We'd like the preview image to be as close as possible to what the printer will
-            //     // actually print. To do this we don't draw text to the page's canvas directly,
-            //     // instead we draw to an offscreen canvas, render that canvas to a monochrome bitmap,
-            //     // then render *that* back to the page's canvas. This is a more accurate picture of
-            //     // what the label will end up looking like.
-
-            //     // A more complex app could do this more gracefully!
-            //     const offscreenContext = new OffscreenCanvas(canvas.width, canvas.height).getContext('2d');
-            //     offscreenContext.font = `30pt ${this.fontName}`;
-            //     offscreenContext.fillStyle = "#000000";
-
-            //     // fillText doesn't do newlines, do that manually
-            //     textarea.value.split('\n').forEach((l, i) => {
-            //         offscreenContext.fillText(l, 5, (i * 31) + 30);
-            //     })
-
-            //     // Now into the monochrome bitmap.
-            //     const offscreenImg = offscreenContext.getImageData(0, 0, canvas.width, canvas.height);
-            //     const monoImg = BitmapGRF.fromCanvasImageData(offscreenImg, { trimWhitespace: false });
-            //     // And finally back onto the page.
-            //     pageContext.putImageData(monoImg.toImageData(), 0, 0);
-            // }
-
-            /** Render the canvas to a document for printing */
-            // private addCanvasImageToLabelDoc(builder: ILabelDocumentBuilder): IDocument {
-            //     const canvas = this.labelForm.querySelector("#labelCanvas") as HTMLCanvasElement;
-            //     const imgData = canvas.getContext('2d').getImageData(0, 0, canvas.width, canvas.height);
-
-            //     // One of the benefits of this library is being able to render images to a canvas element
-            //     // and sending that canvas directly to a label. This allows your webpage to generate complex
-            //     // images and fonts (like emoji!) that EPL/ZPL can't support.
-            //     return builder
-            //         .addImageFromImageData(imgData)
-            //         .addPrintCmd()
-            //         .finalize();
-            // }
-
-            /** Send the contents of the config form as a config label to the printer. */
-            // private async updatePrinterConfig(e: SubmitEvent) {
-            //     e.preventDefault();
-
-            //     // Figure out the right printer
-            //     const formElement = this.configModal.querySelector('form');
-            //     const form = formElement.elements as HTMLFormControlsCollection;
-            //     const printerIdx = parseInt(formElement.querySelector('#modalPrinterIndexText').innerText);
-            //     const printer = this.printers[printerIdx];
-            //     if (printer == null) {
-            //         return;
-            //     }
-
-            //     form.modalSubmit.setAttribute("disabled", "");
-            //     form.modalCancel.setAttribute("disabled", "");
-
-            //     // Pull the values out of the form.
-            //     const darkness = parseInt(form.modalDarkness.value) as DarknessPercent;
-            //     const rawSpeed = parseInt(form.modalSpeed.value) as PrintSpeed;
-            //     const labelWidthInches = parseFloat(form.modalLabelWidth.value);
-            //     const autosense = form.modalWithAutosense.checked;
-
-            //     // Construct the config document with the values from the form
-            //     const configDoc = printer
-            //         .getConfigDocument()
-            //         .setPrintDirection()
-            //         .setLabelHomeOffsetDots(0, 0)
-            //         .setPrintSpeed(rawSpeed)
-            //         .setDarknessConfig(darkness)
-            //         .setLabelDimensions(labelWidthInches);
-            //     const doc = autosense
-            //         ? configDoc.autosenseLabelLength()
-            //         : configDoc.finalize();
-            //     // And send the whole shebang to the printer!
-            //     await printer.sendDocument(doc);
-
-            //     form.modalSubmit.removeAttribute("disabled");
-            //     form.modalCancel.removeAttribute("disabled");
-            //     this.activePrinterIndex = printerIdx;
-            //     this.configModalHandle.hide();
-            // }
+      // The app's logic is wrapped in a class just for ease of reading.
+      class BasicDocumentPrinterApp {
+        constructor(
+          private manager: WebReceipt.UsbDeviceManager<WebReceipt.ReceiptPrinter>,
+          private btnContainer: HTMLElement,
+          private labelForm: HTMLElement,
+          private labelFormInstructions: HTMLElement,
+        ) {
+          // Add a second set of event listeners for printer connect and disconnect to redraw
+          // the printer list when it changes.
+          this.manager.addEventListener('connectedDevice', () => {
+            this.activePrinterIndex = -1;
+            this.redrawPrinterButtons();
+          });
+          this.manager.addEventListener('disconnectedDevice', () => {
+            this.activePrinterIndex = -1;
+            this.redrawPrinterButtons();
+          });
         }
 
-        // With the app class defined we can run it.
-        // First up collect the basic structure of the app
-        const btnContainer          = document.getElementById("printerlist");
-        const labelForm             = document.getElementById("labelForm");
-        const labelFormInstructions = document.getElementById("labelFormInstructions");
-        const configModal           = document.getElementById("printerOptionModal");
+        get printers(): readonly WebReceipt.ReceiptPrinter[] {
+          return this.manager.devices;
+        }
 
-        // And feed that into the app class to manage the elements
-        const app = new BasicDocumentPrinterApp(printerMgr, btnContainer, labelForm, labelFormInstructions, configModal);
-        // and let it take over the UI.
-        await app.init();
-        // Then hang it on the window object so we can play with it elsewhere, like the dev console.
-        window.printer_app = app;
+        // Track which printer is currently selected for operations
+        private _activePrinter = 0;
+        get activePrinter(): WebReceipt.ReceiptPrinter | undefined {
+          return this._activePrinter < 0 || this._activePrinter > this.printers.length
+            ? undefined
+            : this.printers[this._activePrinter];
+        }
+        set activePrinterIndex(printerIdx: number) {
+          this._activePrinter = printerIdx;
+          this.redrawTextCanvas();
+        }
 
-        // Now we'll fire the reconnect since our UI is wired up.
-        await printerMgr.forceReconnect();
+        /** Initialize the app */
+        public async init() {
+          this.redrawPrinterButtons();
+          this.redrawTextCanvas();
+        }
 
-        // We're done here. Bring in the dancing lobsters.
+        /** Erase and re-draw the list of printer buttons in the UI. */
+        private redrawPrinterButtons() {
+          this.btnContainer.innerHTML = '';
+          this.printers.forEach((printer, idx) => this.drawPrinterButton(printer, idx));
+        }
+
+        /** Highlight only the currently selected printer. */
+        private redrawPrinterButtonHighlights() {
+          this.printers.forEach((printer, idx) => {
+            const highlight = this._activePrinter == idx ? "var(--bs-blue)" : "transparent";
+            const element = document.getElementById(`printer_${idx}`)!;
+            element.style.background = `linear-gradient(to right, ${highlight}, ${highlight}, grey, grey)`;
+          });
+        }
+
+        /** Add a printer's button UI to the list of printers. */
+        private drawPrinterButton(printer: WebReceipt.ReceiptPrinter, idx: number) {
+          const highlight = this._activePrinter == idx ? "var(--bs-blue)" : "transparent";
+
+          // Generate a new label printer button for the given printer.
+          const element = document.createElement("div");
+          element.innerHTML = `
+          <li id="printer_${idx}" data-printer-idx="${idx}"
+              class="list-group-item d-flex flex-row justify-content-between sligh-items-start"
+              style="background: linear-gradient(to right, ${highlight}, ${highlight}, grey, grey);">
+              <div class="col-sm-8">
+                  <div class="col-sm-12">
+                      <span data-serial="${printer.printerOptions.serialNumber}">${printer.printerOptions.serialNumber}</span>
+                  </div>
+                  <div class="col-sm-12">
+                      <span>${printer.printerOptions.charactersPerLine} cpl</span>
+                  </div>
+              </div>
+              <div class="d-flex flex-row justify-content-end">
+                  <div class="btn-group" role="group" aria-label="Printer button group">
+                      <button id="printto_${idx}" class="btn btn-success btn-lg" data-printer-idx="${idx}">🖨</button>
+                          <button class="btn btn-success dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
+                              <span class="visually-hidden">Settings</span>
+                          </button>
+                          <ul class="dropdown-menu">
+                              <li><a id="printtest_${idx}"   data-printer-idx="${idx}" class="dropdown-item" href="#">
+                                  Print test page
+                              </a></li>
+                              <li><a id="printconfig_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
+                                  Print config
+                              </a></li>
+                              <li><a id="drawerkick_${idx}"  data-printer-idx="${idx}" class="dropdown-item" href="#">
+                                  Kick drawer out
+                              </a></li>
+                          </ul>
+                      </div>
+                  </div>
+              </div>
+          </li>`;
+          // And slap it into the button container.
+          this.btnContainer.appendChild(element);
+
+          // Then wire up the button events so they work.
+          document.getElementById(`printto_${idx}`)!
+            .addEventListener('click', async (e) => {
+              e.preventDefault();
+              const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+              const printer = this.printers[printerIdx];
+              const textarea = this.labelForm.querySelector('#labelFormText') as HTMLTextAreaElement;
+              const rawReceiptline = textarea.value;
+              const doc = WebReceipt.parseReceiptLineToDocument(rawReceiptline, printer.printerOptions);
+              await printer.sendDocument(doc);
+            });
+          document.getElementById(`printer_${idx}`)!
+            .addEventListener('click', async (e) => {
+              e.preventDefault();
+              const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+              if (this._activePrinter == printerIdx) {
+                // Don't refresh anything if we already have this printer selected..
+                return;
+              }
+              this.activePrinterIndex = printerIdx;
+              this.redrawPrinterButtonHighlights();
+              this.redrawTextCanvas();
+            });
+          document.getElementById(`printtest_${idx}`)!
+            .addEventListener('click', async (e) => {
+              e.preventDefault();
+              const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+              const printer = this.printers[printerIdx];
+              const doc = {
+                commands: [new WebReceipt.TestPrint('rolling')]
+              };
+              await printer.sendDocument(doc);
+            });
+          document.getElementById(`printconfig_${idx}`)!
+            .addEventListener('click', async (e) => {
+              e.preventDefault();
+              const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+              const printer = this.printers[printerIdx];
+              const doc = {
+                commands: [new WebReceipt.TestPrint('printerStatus')]
+              };
+              await printer.sendDocument(doc);
+            });
+          document.getElementById(`drawerkick_${idx}`)!
+            .addEventListener('click', async (e) => {
+              e.preventDefault();
+              const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+              const printer = this.printers[printerIdx];
+              const doc = {
+                commands: [new WebReceipt.PulseCommand()]
+              };
+              await printer.sendDocument(doc);
+            });
+        }
+
+        /** Redraw the text canvas size according to the printer. */
+        private redrawTextCanvas() {
+          const printer = this.activePrinter;
+          if (printer == null) {
+            this.labelForm.classList.add('d-none');
+            this.labelFormInstructions.classList.remove('d-none');
+            return;
+          } else {
+            this.labelForm.classList.remove('d-none');
+            this.labelFormInstructions.classList.add('d-none');
+          }
+
+          const textarea = this.labelForm.querySelector('#labelFormText') as HTMLTextAreaElement;
+          textarea.value = "Enter your ReceiptLine text here!";
+        }
+      }
+
+      // With the app class defined we can run it.
+      // First up collect the basic structure of the app
+      const btnContainer          = document.getElementById("printerlist")!;
+      const labelForm             = document.getElementById("labelForm")!;
+      const labelFormInstructions = document.getElementById("labelFormInstructions")!;
+
+      // And feed that into the app class to manage the elements
+      const app = new BasicDocumentPrinterApp(printerMgr, btnContainer, labelForm, labelFormInstructions);
+      // and let it take over the UI.
+      await app.init();
+
+      // Make the TypeScript type system happy by adding a property to the Window object.
+      declare global {
+        interface Window { printer_app: BasicDocumentPrinterApp }
+      }
+      // Now we can access our printer in the dev console if we want to mess with it!
+      window.printer_app = app;
+
+      // Now we'll fire the reconnect since our UI is wired up.
+      await printerMgr.forceReconnect();
+
+      // We're done here. Bring in the dancing lobsters.
     </script>
     <row>
         <div class="container-fluid">
@@ -555,81 +390,6 @@
             </div>
         </div>
     </row>
-    <div id="printerOptionModal" class="modal" tabindex="-1">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <form id="printerSettingsForm">
-                    <div class="modal-header">
-                        <h5 class="modal-title">Label Settings</h5>
-                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                    </div>
-                    <div class="modal-body">
-                        <label for="modalPrinterIndex" class="form-label">Printer ID</label>
-                        <div class="input-group mb-3">
-                            <span id="modalPrinterIndexText" class="input-group-text">42Q424242424</span>
-                            <input id="modalPrinterIndex" class="form-control" type="text" value="-1"
-                                aria-label="Printer ID" aria-describedby="modalPrinterIndexText" disabled readonly>
-                        </div>
-                        <div class="mb-3">
-                            <div class="row">
-                                <div class="col">
-                                    <label for="modalLabelWidth" class="form-label">Label Width</label>
-                                    <div class="input-group mb-3">
-                                        <input id="modalLabelWidth" type="text" class="form-control" placeholder="2.25"
-                                            aria-label="Width" required pattern="\d+\.*\d*">
-                                        <span id="modalLabelWidthText" class="input-group-text">in</span>
-                                    </div>
-                                </div>
-                                <div class="col">
-                                    <label for="modalLabelHeight" class="form-label">Label Height</label>
-                                    <div class="input-group mb-3">
-                                        <input id="modalLabelHeight" type="text" class="form-control" placeholder="2.25"
-                                            aria-label="Height" required pattern="\d+\.*\d*" readonly>
-                                        <span id="modalLabelHeightText" class="input-group-text">in</span>
-                                    </div>
-                                </div>
-                                <div class="col">
-                                    <div class="form-check form-switch">
-                                        <input id="modalWithAutosense" type="checkbox" role="switch" class="form-check-input"
-                                            aria-label="RunAutosense">
-                                        <label for="modalWithAutosense" class="form-check-label">Perform autosense</label>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="mb-3">
-                            <div class="row">
-                                <div class="col row mb-3">
-                                    <label for="modalDarkness" class="col-sm-5 col-form-label">Darkness</label>
-                                    <div class="col-sm-7">
-                                        <div class="input-group col-sm-7">
-                                            <input type="number" min="1" max="99" id="modalDarkness" class="form-control" aria-label="Darkness"/>
-                                            <span class="input-group-text">%</span>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="col row mb-3">
-                                    <label for="modalSpeed" class="col-sm-5 col-form-label">Speed</label>
-                                    <div class="col-sm-7">
-                                        <select id="modalSpeed" class="form-select" aria-label="Speed">
-                                            <option value="3">1.5 ips</option>
-                                            <option value="4">2 ips</option>
-                                            <option value="5">2.5 ips</option>
-                                            <option value="7">3.5 ips</option>
-                                        </select>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="modal-footer">
-                        <button id="modalCancel" type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-                        <input id="modalSubmit" type="submit" class="btn btn-primary" value="Save">
-                    </div>
-                </form>
-            </div>
-        </div>
-    </div>
     <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.10.2/dist/umd/popper.min.js"
         integrity="sha384-7+zCNj/IqJ95wo16oMtfsKbZ9ccEh31eOz1HGyDuCQ6wgnyJNSYdrPa03rtR1zdB"
         crossorigin="anonymous"></script>

--- a/demo/test_index.ts
+++ b/demo/test_index.ts
@@ -1,0 +1,255 @@
+import * as WebReceipt from '../src/index.js';
+// This file exists to test the index.html's typescript. Unfortunately there isn't
+// a good way to configure Visual Studio Code to, well, treat it as typescript.
+////////////////////////////////////////////////////////////////////////////////
+
+// First import the lib!
+//import * as WebReceipt from 'web-receiptline-printer';
+
+// For this demo we're going to make use of the USB printer manager
+// so it can take care of concerns like the USB connect and disconnect events.
+const printerMgr = new WebReceipt.UsbDeviceManager<WebReceipt.ReceiptPrinter>(
+  window.navigator.usb,
+  WebReceipt.ReceiptPrinter.fromUSBDevice,
+  {
+    // Enable debugging, so the dev console can fill up with interesting messages!
+    debug: true,
+    requestOptions: {
+      // Limit the USB devices we try to connect to.
+      filters: [
+        {
+          vendorId: 0x04B8, // Epson
+          //productId: 0x0202, // TM-T88V
+        }
+      ]
+    }
+  }
+);
+
+// We'll wire up some basic event listeners to the printer manager.
+// First, a button to prompt a user to add a printer.
+const addPrinterBtn = document.getElementById('addprinter')!;
+addPrinterBtn.addEventListener('click', async () => printerMgr.promptForNewDevice());
+
+// Next a button to manually refresh all printers, just in case.
+const refreshPrinterBtn = document.getElementById('refreshPrinters')!;
+refreshPrinterBtn.addEventListener('click', async () => printerMgr.forceReconnect());
+
+// Next we wire up some events on the device manager itself.
+printerMgr.addEventListener('connectedDevice', ({ detail }) => {
+  const printer = detail.device;
+  const config = printer.printerOptions;
+  console.log(`Printer is a ${config.model} by ${config.manufacturer}, serial ${config.serialNumber}`);
+  console.log(`Printer has ${config.charactersPerLine} characters per line`);
+});
+
+// There's also an event that will tell you when a printer disconnects.
+printerMgr.addEventListener('disconnectedDevice', ({ detail }) => {
+  const printer = detail.device;
+  // TODO: Hide appropriate interface.
+  console.log(`Lost printer ${printer.printerModel} (${printer.printerOptions.serialNumber}).`);
+});
+
+// The browser will remember printers that were previously connected, and
+// when the page loads it will automatically reconnect to them. Our code wasn't
+// running yet though, so we missed it. It's good practice to force a
+// reconnect once your event handlers are ready. Like this:
+//await printerMgr.forceReconnect();
+// Before we do that in this demo we first want to set up the UI app.
+
+// And that's all there is to setup! The page can now talk to printers.
+// The rest of this demo is an example of a basic receipt printer app.
+
+// The app's logic is wrapped in a class just for ease of reading.
+class BasicDocumentPrinterApp {
+  constructor(
+    private manager: WebReceipt.UsbDeviceManager<WebReceipt.ReceiptPrinter>,
+    private btnContainer: HTMLElement,
+    private labelForm: HTMLElement,
+    private labelFormInstructions: HTMLElement,
+  ) {
+    // Add a second set of event listeners for printer connect and disconnect to redraw
+    // the printer list when it changes.
+    this.manager.addEventListener('connectedDevice', () => {
+      this.activePrinterIndex = -1;
+      this.redrawPrinterButtons();
+    });
+    this.manager.addEventListener('disconnectedDevice', () => {
+      this.activePrinterIndex = -1;
+      this.redrawPrinterButtons();
+    });
+  }
+
+  get printers(): readonly WebReceipt.ReceiptPrinter[] {
+    return this.manager.devices;
+  }
+
+  // Track which printer is currently selected for operations
+  private _activePrinter = 0;
+  get activePrinter(): WebReceipt.ReceiptPrinter | undefined {
+    return this._activePrinter < 0 || this._activePrinter > this.printers.length
+      ? undefined
+      : this.printers[this._activePrinter];
+  }
+  set activePrinterIndex(printerIdx: number) {
+    this._activePrinter = printerIdx;
+    this.redrawTextCanvas();
+  }
+
+  /** Initialize the app */
+  public async init() {
+    this.redrawPrinterButtons();
+    this.redrawTextCanvas();
+  }
+
+  /** Erase and re-draw the list of printer buttons in the UI. */
+  private redrawPrinterButtons() {
+    this.btnContainer.innerHTML = '';
+    this.printers.forEach((printer, idx) => this.drawPrinterButton(printer, idx));
+  }
+
+  /** Highlight only the currently selected printer. */
+  private redrawPrinterButtonHighlights() {
+    this.printers.forEach((printer, idx) => {
+      const highlight = this._activePrinter == idx ? "var(--bs-blue)" : "transparent";
+      const element = document.getElementById(`printer_${idx}`)!;
+      element.style.background = `linear-gradient(to right, ${highlight}, ${highlight}, grey, grey)`;
+    });
+  }
+
+  /** Add a printer's button UI to the list of printers. */
+  private drawPrinterButton(printer: WebReceipt.ReceiptPrinter, idx: number) {
+    const highlight = this._activePrinter == idx ? "var(--bs-blue)" : "transparent";
+
+    // Generate a new label printer button for the given printer.
+    const element = document.createElement("div");
+    element.innerHTML = `
+    <li id="printer_${idx}" data-printer-idx="${idx}"
+        class="list-group-item d-flex flex-row justify-content-between sligh-items-start"
+        style="background: linear-gradient(to right, ${highlight}, ${highlight}, grey, grey);">
+        <div class="col-sm-8">
+            <div class="col-sm-12">
+                <span data-serial="${printer.printerOptions.serialNumber}">${printer.printerOptions.serialNumber}</span>
+            </div>
+            <div class="col-sm-12">
+                <span>${printer.printerOptions.charactersPerLine} cpl</span>
+            </div>
+        </div>
+        <div class="d-flex flex-row justify-content-end">
+            <div class="btn-group" role="group" aria-label="Printer button group">
+                <button id="printto_${idx}" class="btn btn-success btn-lg" data-printer-idx="${idx}">🖨</button>
+                    <button class="btn btn-success dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
+                        <span class="visually-hidden">Settings</span>
+                    </button>
+                    <ul class="dropdown-menu">
+                        <li><a id="printtest_${idx}"   data-printer-idx="${idx}" class="dropdown-item" href="#">
+                            Print test page
+                        </a></li>
+                        <li><a id="printconfig_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
+                            Print config
+                        </a></li>
+                        <li><a id="drawerkick_${idx}"  data-printer-idx="${idx}" class="dropdown-item" href="#">
+                            Kick drawer out
+                        </a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </li>`;
+    // And slap it into the button container.
+    this.btnContainer.appendChild(element);
+
+    // Then wire up the button events so they work.
+    document.getElementById(`printto_${idx}`)!
+      .addEventListener('click', async (e) => {
+        e.preventDefault();
+        const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+        const printer = this.printers[printerIdx];
+        const textarea = this.labelForm.querySelector('#labelFormText') as HTMLTextAreaElement;
+        const rawReceiptline = textarea.value;
+        const doc = WebReceipt.parseReceiptLineToDocument(rawReceiptline, printer.printerOptions);
+        await printer.sendDocument(doc);
+      });
+    document.getElementById(`printer_${idx}`)!
+      .addEventListener('click', async (e) => {
+        e.preventDefault();
+        const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+        if (this._activePrinter == printerIdx) {
+          // Don't refresh anything if we already have this printer selected..
+          return;
+        }
+        this.activePrinterIndex = printerIdx;
+        this.redrawPrinterButtonHighlights();
+        this.redrawTextCanvas();
+      });
+    document.getElementById(`printtest_${idx}`)!
+      .addEventListener('click', async (e) => {
+        e.preventDefault();
+        const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+        const printer = this.printers[printerIdx];
+        const doc = {
+          commands: [new WebReceipt.TestPrint('rolling')]
+        };
+        await printer.sendDocument(doc);
+      });
+    document.getElementById(`printconfig_${idx}`)!
+      .addEventListener('click', async (e) => {
+        e.preventDefault();
+        const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+        const printer = this.printers[printerIdx];
+        const doc = {
+          commands: [new WebReceipt.TestPrint('printerStatus')]
+        };
+        await printer.sendDocument(doc);
+      });
+    document.getElementById(`drawerkick_${idx}`)!
+      .addEventListener('click', async (e) => {
+        e.preventDefault();
+        const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+        const printer = this.printers[printerIdx];
+        const doc = {
+          commands: [new WebReceipt.PulseCommand()]
+        };
+        await printer.sendDocument(doc);
+      });
+  }
+
+  /** Redraw the text canvas size according to the printer. */
+  private redrawTextCanvas() {
+    const printer = this.activePrinter;
+    if (printer == null) {
+      this.labelForm.classList.add('d-none');
+      this.labelFormInstructions.classList.remove('d-none');
+      return;
+    } else {
+      this.labelForm.classList.remove('d-none');
+      this.labelFormInstructions.classList.add('d-none');
+    }
+
+    const textarea = this.labelForm.querySelector('#labelFormText') as HTMLTextAreaElement;
+    textarea.value = "Enter your ReceiptLine text here!";
+  }
+}
+
+// With the app class defined we can run it.
+// First up collect the basic structure of the app
+const btnContainer          = document.getElementById("printerlist")!;
+const labelForm             = document.getElementById("labelForm")!;
+const labelFormInstructions = document.getElementById("labelFormInstructions")!;
+
+// And feed that into the app class to manage the elements
+const app = new BasicDocumentPrinterApp(printerMgr, btnContainer, labelForm, labelFormInstructions);
+// and let it take over the UI.
+await app.init();
+
+// Make the TypeScript type system happy by adding a property to the Window object.
+declare global {
+  interface Window { printer_app: BasicDocumentPrinterApp }
+}
+// Now we can access our printer in the dev console if we want to mess with it!
+window.printer_app = app;
+
+// Now we'll fire the reconnect since our UI is wired up.
+await printerMgr.forceReconnect();
+
+// We're done here. Bring in the dancing lobsters.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-receiptline-printer",
-  "version": "0.1.0-rc1",
-  "description": "A small Library for printing ReceiptLine documents to various receipt printers from a browser.",
+  "version": "0.2.0-rc2",
+  "description": "A small library for printing ReceiptLine documents to various receipt printers from a browser.",
   "type": "module",
   "repository": {
     "type": "git",
@@ -13,6 +13,13 @@
     "url": "https://github.com/Cellivar/WebReceiptLinePrinter/issues"
   },
   "homepage": "https://github.com/Cellivar/WebReceiptLinePrinter",
+  "keywords": [
+    "receipt_printer",
+    "receiptline",
+    "webusb",
+    "epson",
+    "tm-t88v"
+  ],
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",

--- a/src/Documents/CommandSet.ts
+++ b/src/Documents/CommandSet.ts
@@ -33,7 +33,8 @@ export interface CommandSet<TOutput> {
   /** Transpile a single command, tracking its effects to a document. */
   transpileCommand(
     cmd: Cmds.IPrinterCommand,
-    docMetadata: TranspiledDocumentState): TOutput | TranspileDocumentError;
+    docMetadata: TranspiledDocumentState
+  ): TOutput | TranspileDocumentError;
 
   /** Combine separate commands into one series of commands. */
   combineCommands(...commands: TOutput[]): TOutput;
@@ -46,7 +47,6 @@ export function exhaustiveMatchGuard(_: never): never {
 /** Interface of document state effects carried between individual commands. */
 export interface TranspiledDocumentState {
   lineSpacing: number;
-  dpi: number;
   charactersPerLine: number;
 
   margin: {

--- a/src/NumericRange.test.ts
+++ b/src/NumericRange.test.ts
@@ -1,15 +1,16 @@
-import { test, expect } from 'vitest';
+import { test, expect, describe } from 'vitest';
 import { clampToRange } from './NumericRange.js';
 
+describe("clampToRange tests", () => {
+  test('high number is clamped down', () => {
+    expect(clampToRange(5, 0, 2)).toBe(2);
+  });
 
-test('high number is clamped down', () => {
-  expect(clampToRange(5, 0, 2)).toBe(2);
-});
+  test('low number is clamped up', () => {
+    expect(clampToRange(-1, 0, 5)).toBe(0);
+  });
 
-test('low number is clamped up', () => {
-  expect(clampToRange(-1, 0, 5)).toBe(0);
-});
-
-test('in-range number is not modified', () => {
-  expect(clampToRange(3, 0, 5)).toBe(3);
+  test('in-range number is not modified', () => {
+    expect(clampToRange(3, 0, 5)).toBe(3);
+  });
 });

--- a/src/Printers/Communication/DeviceCommunication.ts
+++ b/src/Printers/Communication/DeviceCommunication.ts
@@ -24,10 +24,17 @@ export interface IDeviceCommunicationOptions {
 
 export interface IDevice {
   /** Close the connection to this device and clean up unmanaged resources. */
-  dispose(): Promise<void>
+  dispose(): Promise<void>;
+
+  /** Whether the device is connected. */
+  get connected(): boolean;
 
   /** A promise indicating this device is ready to be used. */
   ready: Promise<boolean>;
+}
+
+export interface IDeviceEvent<TDevice> {
+  device: TDevice;
 }
 
 /** Static metadata for a connected device. */

--- a/src/Printers/Languages/EscPos/EscPos.ts
+++ b/src/Printers/Languages/EscPos/EscPos.ts
@@ -103,7 +103,6 @@ export class EscPos extends RawCommandSet {
       },
       printWidth: media.charactersPerLine,
       textFormat: {},
-      dpi: 5,
       codepage: "CP437"
     };
   }
@@ -142,7 +141,8 @@ export class EscPos extends RawCommandSet {
 
   public transpileCommand(
     cmd: Cmds.IPrinterCommand,
-    docState: EscPosDocState): Uint8Array {
+    docState: EscPosDocState
+  ): Uint8Array {
     // Do not suggest a better way to do this unless it's in the form of a complete PR.
     switch (cmd.type) {
       default:

--- a/src/Printers/Languages/RawCommandSet.ts
+++ b/src/Printers/Languages/RawCommandSet.ts
@@ -43,7 +43,8 @@ export abstract class RawCommandSet implements CommandSet<Uint8Array> {
 
   public abstract transpileCommand(
     cmd: Cmds.IPrinterCommand,
-    docState: TranspiledDocumentState): Uint8Array;
+    docState: TranspiledDocumentState
+  ): Uint8Array | TranspileDocumentError;
 
   protected extendedCommandHandler(
     cmd: Cmds.IPrinterCommand,


### PR DESCRIPTION
A bug that only arose when I was testing with my [other library](https://github.com/Cellivar/WebZLP/pull/48), connecting device events would react to _any_ devices connecting. This caused some fighting.

This adds filtering identical to the filtering done when prompting the user for a new device.