### PR TITLE
Fix ESCPOS message packet detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-receiptline-printer",
-  "version": "0.2.0-rc4",
+  "version": "0.2.0-rc5",
   "description": "A small library for printing ReceiptLine documents to various receipt printers from a browser.",
   "type": "module",
   "repository": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,9 @@
       "DOM",
       "DOM.Iterable"
     ],
+    "types": [
+      "vitest/importMeta"
+    ],
     "skipLibCheck": false,
     "isolatedModules": true,
     "noEmit": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,10 +13,14 @@ export default defineConfig({
     },
     minify: false,
   },
+  define: {
+    'import.meta.vitest': 'undefined',
+  },
   plugins: [dts(), eslint({
     failOnError: false
   })],
   test: {
+    includeSource: ['src/**/*.{js,ts}'],
     coverage: {
       // you can include other reporters, but 'json-summary' is required, json is recommended
       reporter: ['text', 'json-summary', 'json'],


### PR DESCRIPTION
I bamboozled myself by using a low roll of receipt paper for testing. With a fresh roll I noticed the end-of-print status message wasn't properly being handled and could cause hung awaits.

I added tests this time!